### PR TITLE
Fix order of records after merging labels and works archive

### DIFF
--- a/synergy_dataset/base.py
+++ b/synergy_dataset/base.py
@@ -204,7 +204,7 @@ class Dataset(object):
             dict: Dictionary of the dataset
         """
 
-        records = {}
+        records = {k: None for k, v in self.labels.items()}
         for work, label_included in self.iter():
             if isinstance(variables, dict):
                 record = {}

--- a/tests/test_synergy.py
+++ b/tests/test_synergy.py
@@ -1,3 +1,5 @@
+import pytest
+
 from synergy_dataset import Dataset
 from synergy_dataset import iter_datasets
 
@@ -10,3 +12,12 @@ def test_build_dataset():
     d = Dataset("van_de_Schoot_2018")
 
     d.to_dict()
+
+
+@pytest.mark.parametrize("dataset_name", [("Walker_2018",), ("van_de_Schoot_2018",)])
+def test_order_iter_dataset(dataset_name):
+    d = Dataset(dataset_name)
+
+    keys = [k for k, v in d.to_dict().items()]
+
+    assert keys == list(d.labels.keys())

--- a/tests/test_synergy.py
+++ b/tests/test_synergy.py
@@ -14,7 +14,7 @@ def test_build_dataset():
     d.to_dict()
 
 
-@pytest.mark.parametrize("dataset_name", [("Walker_2018",), ("van_de_Schoot_2018",)])
+@pytest.mark.parametrize("dataset_name", ["Walker_2018", "van_de_Schoot_2018"])
 def test_order_iter_dataset(dataset_name):
     d = Dataset(dataset_name)
 


### PR DESCRIPTION
No impact on the results, but minor impact on the ordering of records in the dataset. Dataset itself is not affected, only the Python package. 

Todo: add unit test